### PR TITLE
Fix homing vector normalization

### DIFF
--- a/src/game/entities/Orb.ts
+++ b/src/game/entities/Orb.ts
@@ -46,7 +46,7 @@ export class Orb {
 
     const homing = game.modifiers.homingStrength;
     if (homing > 0) {
-      let nearest: { dx: number; dy: number } | undefined;
+      let nearest: Vector2 | undefined;
       let closest = Infinity;
       for (const enemy of game.enemies) {
         if (!enemy.alive) continue;
@@ -55,7 +55,7 @@ export class Orb {
         const dist = dx * dx + dy * dy;
         if (dist < closest) {
           closest = dist;
-          nearest = { dx, dy };
+          nearest = { x: dx, y: dy };
         }
       }
       if (nearest) {


### PR DESCRIPTION
## Summary
- ensure the homing assist uses proper vector components when steering toward enemies
- prevent NaN velocities that left pucks stuck when the Seeker Fletching modifier is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8e2220104832da45a0e078308ebbd