### PR TITLE
Add stacking upgrade draft alongside periodic core modifiers

### DIFF
--- a/src/game/entities/Enemy.ts
+++ b/src/game/entities/Enemy.ts
@@ -18,6 +18,8 @@ export abstract class Enemy {
   public maxHp: number;
   public shield = 0;
   public alive = true;
+  public isElite = false;
+  public isBoss = false;
   protected elapsed = 0;
   protected baseSpeed: number;
   private slowTimer = 0;

--- a/src/game/entities/Orb.ts
+++ b/src/game/entities/Orb.ts
@@ -20,6 +20,8 @@ export class Orb {
   public damage: number;
   public splitOnImpact: boolean;
   public alive = true;
+  public bounceCount = 0;
+  public pendingWallDamageBonus = 0;
 
   constructor(position: Vector2, velocity: Vector2, options: OrbOptions = {}) {
     this.id = ORB_ID++;
@@ -38,6 +40,8 @@ export class Orb {
       damage: this.damage,
       splitOnImpact: false, // Split orbs lose the ability to split further
     });
+    copy.bounceCount = this.bounceCount;
+    copy.pendingWallDamageBonus = this.pendingWallDamageBonus;
     return copy;
   }
 
@@ -98,6 +102,6 @@ export class Orb {
   }
 
   private onWallBounce(game: Game) {
-    game.emitWallHit(this.position);
+    game.emitWallHit(this.position, this);
   }
 }

--- a/src/game/modifiers.ts
+++ b/src/game/modifiers.ts
@@ -1,5 +1,15 @@
 import type { ModifierState, RunModifierDefinition } from './types';
 
+export interface DraftContext {
+  lives: number;
+  maxLives: number;
+}
+
+export type DraftModifier = RunModifierDefinition & {
+  unique?: boolean;
+  available?(state: ModifierState, context: DraftContext): boolean;
+};
+
 const ensureSlow = (state: ModifierState, duration: number, factor: number) => {
   const existing = state.slowEffect;
   if (!existing) {
@@ -38,7 +48,7 @@ const ensureChain = (state: ModifierState, range: number, damage: number, interv
   };
 };
 
-export const ALL_MODIFIERS: RunModifierDefinition[] = [
+export const MAJOR_MODIFIERS: DraftModifier[] = [
   {
     id: 'bulwarkCore',
     name: 'Bulwark Core',
@@ -123,4 +133,80 @@ export const ALL_MODIFIERS: RunModifierDefinition[] = [
   },
 ];
 
-export const MODIFIER_MAP = new Map(ALL_MODIFIERS.map((modifier) => [modifier.id, modifier]));
+export const UPGRADE_MODIFIERS: DraftModifier[] = [
+  {
+    id: 'damageBoost',
+    name: 'Damage Amplifier',
+    description: '+5% damage.',
+    rarity: 'common',
+    apply(state) {
+      state.damageMultiplier += 0.05;
+    },
+  },
+  {
+    id: 'comboHeatDamageBoost',
+    name: 'Combo Flux',
+    description: '+0.4% damage per Combo Heat.',
+    rarity: 'common',
+    apply(state) {
+      state.comboHeatDamagePercent += 0.004;
+    },
+  },
+  {
+    id: 'bounceDamageBoost',
+    name: 'Ricochet Matrix',
+    description: '+5% damage per wall bounce.',
+    rarity: 'common',
+    apply(state) {
+      state.bounceDamagePercent += 0.05;
+    },
+  },
+  {
+    id: 'bossDamageBoost',
+    name: 'Predator Lock',
+    description: '+10% damage vs bosses & elites.',
+    rarity: 'uncommon',
+    apply(state) {
+      state.bossDamageMultiplier += 0.1;
+    },
+  },
+  {
+    id: 'wallHitDamageBoost',
+    name: 'Impact Condenser',
+    description: '+15% damage after a wall hit (next hit).',
+    rarity: 'uncommon',
+    apply(state) {
+      state.wallHitDamageBonusPercent += 0.15;
+    },
+  },
+  {
+    id: 'restoreHeart',
+    name: 'Restore Heart',
+    description: 'Recover one lost heart.',
+    rarity: 'common',
+    apply(_state) {},
+    available(_state, context) {
+      return context.lives < context.maxLives;
+    },
+  },
+  {
+    id: 'seekerHomingBoost',
+    name: 'Seeker Calibration',
+    description: '+15% homing strength if Seeker Fletching is equipped.',
+    rarity: 'uncommon',
+    apply(state) {
+      if (state.homingStrength > 0) {
+        state.homingStrength *= 1.15;
+      }
+    },
+    available(state) {
+      return state.homingStrength > 0;
+    },
+  },
+];
+
+export const ALL_DRAFT_MODIFIERS: DraftModifier[] = [...MAJOR_MODIFIERS, ...UPGRADE_MODIFIERS];
+
+export const MODIFIER_MAP = new Map(
+  ALL_DRAFT_MODIFIERS.map((modifier) => [modifier.id, modifier]),
+);

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -14,7 +14,14 @@ export type RunModifierId =
   | 'volatileCore'
   | 'fractalSplinters'
   | 'stormLattice'
-  | 'triVolley';
+  | 'triVolley'
+  | 'damageBoost'
+  | 'comboHeatDamageBoost'
+  | 'bounceDamageBoost'
+  | 'bossDamageBoost'
+  | 'wallHitDamageBoost'
+  | 'restoreHeart'
+  | 'seekerHomingBoost';
 
 export interface ModifierState {
   orbSizeMultiplier: number;
@@ -26,6 +33,11 @@ export interface ModifierState {
   splitOnImpact: boolean;
   chainLightning?: { range: number; damage: number; interval: number; cooldown: number };
   tripleLaunch: boolean;
+  damageMultiplier: number;
+  comboHeatDamagePercent: number;
+  bounceDamagePercent: number;
+  bossDamageMultiplier: number;
+  wallHitDamageBonusPercent: number;
   lastPicked?: RunModifierId;
 }
 

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,8 +1,8 @@
 import type { HudData, RunModifierId } from '../game/types';
-import { ALL_MODIFIERS } from '../game/modifiers';
+import { ALL_DRAFT_MODIFIERS } from '../game/modifiers';
 
 const modifierLabels: Record<RunModifierId, string> = Object.fromEntries(
-  ALL_MODIFIERS.map((mod) => [mod.id, mod.name]),
+  ALL_DRAFT_MODIFIERS.map((mod) => [mod.id, mod.name]),
 ) as Record<RunModifierId, string>;
 
 export class HUD {

--- a/src/ui/PowerDraftOverlay.ts
+++ b/src/ui/PowerDraftOverlay.ts
@@ -1,10 +1,11 @@
-import type { RunModifierDefinition } from '../game/types';
+import type { DraftModifier } from '../game/modifiers';
 
 export class PowerDraftOverlay {
   public readonly element: HTMLDivElement;
   private readonly optionsGrid: HTMLDivElement;
   private readonly title: HTMLHeadingElement;
-  private resolve?: (choice: RunModifierDefinition) => void;
+  private readonly subtitle: HTMLParagraphElement;
+  private resolve?: (choice: DraftModifier) => void;
   private active = false;
 
   constructor() {
@@ -14,24 +15,30 @@ export class PowerDraftOverlay {
     this.title = document.createElement('h2');
     this.title.textContent = 'Choose your upgrade';
 
-    const subtitle = document.createElement('p');
-    subtitle.textContent = 'Select one of the three experimental puck mods.';
+    this.subtitle = document.createElement('p');
+    this.subtitle.textContent = 'Select one of the three experimental puck mods.';
 
     this.optionsGrid = document.createElement('div');
     this.optionsGrid.className = 'power-draft__grid';
 
-    this.element.append(this.title, subtitle, this.optionsGrid);
+    this.element.append(this.title, this.subtitle, this.optionsGrid);
     this.hide();
   }
 
-  async present(options: RunModifierDefinition[]): Promise<RunModifierDefinition> {
+  async present(
+    options: DraftModifier[],
+    config?: { title?: string; subtitle?: string },
+  ): Promise<DraftModifier> {
     if (this.active) {
       throw new Error('Power draft already active');
     }
     this.active = true;
     this.optionsGrid.replaceChildren();
+    this.title.textContent = config?.title ?? 'Choose your upgrade';
+    this.subtitle.textContent =
+      config?.subtitle ?? 'Select one of the three experimental puck mods.';
 
-    return new Promise<RunModifierDefinition>((resolve) => {
+    return new Promise<DraftModifier>((resolve) => {
       this.resolve = resolve;
       for (const option of options) {
         this.optionsGrid.appendChild(this.createOptionCard(option));
@@ -50,7 +57,7 @@ export class PowerDraftOverlay {
     this.element.style.pointerEvents = 'auto';
   }
 
-  private createOptionCard(option: RunModifierDefinition) {
+  private createOptionCard(option: DraftModifier) {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `draft-card rarity-${option.rarity}`;
@@ -71,7 +78,7 @@ export class PowerDraftOverlay {
     return button;
   }
 
-  private finish(option: RunModifierDefinition) {
+  private finish(option: DraftModifier) {
     if (!this.active) return;
     this.active = false;
     this.hide();


### PR DESCRIPTION
## Summary
- offer repeatable damage-tuning upgrades after every wave and gate core modifiers to every third wave
- introduce new stacking stats in the modifier state and apply them to orb damage, including bounce and wall-hit bonuses
- extend the draft overlay and HUD to support the new upgrade options and heart restoration

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8f3394a3c832d9678689292235e3b