### PR TITLE
Add pause overlay to review modifiers while paused

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './style.css';
 import { Game } from './game/Game';
 import { HUD } from './ui/HUD';
+import { PauseOverlay } from './ui/PauseOverlay';
 import { PowerDraftOverlay } from './ui/PowerDraftOverlay';
 
 declare global {
@@ -25,11 +26,12 @@ function bootstrap() {
 
   const hud = new HUD();
   const draft = new PowerDraftOverlay();
+  const pauseOverlay = new PauseOverlay();
 
-  shell.append(canvas, hud.element, hud.toastElement, draft.element);
+  shell.append(canvas, hud.element, hud.toastElement, pauseOverlay.element, draft.element);
   app.appendChild(shell);
 
-  const game = new Game(canvas, hud, draft);
+  const game = new Game(canvas, hud, draft, pauseOverlay);
   window.slingpunkGame = game;
 
   hud.onPauseRequested(() => {

--- a/src/style.css
+++ b/src/style.css
@@ -278,12 +278,235 @@ canvas.game-canvas {
   color: rgba(255, 200, 255, 0.98);
 }
 
-@media (max-width: 640px) {
-  #app {
-    padding: 0;
-  }
-  .game-shell {
-    border-radius: 0;
-    border-width: 0;
-  }
+.pause-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  background: rgba(7, 5, 20, 0.65);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
 }
+
+.pause-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.pause-overlay__panel {
+  width: min(100%, 680px);
+  max-height: calc(100% - 2rem);
+  overflow-y: auto;
+  background: linear-gradient(180deg, rgba(16, 20, 44, 0.95) 0%, rgba(8, 12, 30, 0.98) 100%);
+  border: 1px solid rgba(118, 169, 255, 0.45);
+  border-radius: 22px;
+  padding: 1.75rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 30px 80px rgba(8, 12, 32, 0.6);
+  color: #f2f8ff;
+}
+
+.pause-overlay__panel::-webkit-scrollbar {
+  width: 6px;
+}
+
+.pause-overlay__panel::-webkit-scrollbar-thumb {
+  background: rgba(118, 169, 255, 0.4);
+  border-radius: 999px;
+}
+
+.pause-overlay__heading h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8dedff;
+}
+
+.pause-overlay__heading p {
+  margin: 0.4rem 0 0;
+  color: rgba(220, 236, 255, 0.78);
+  font-size: 0.95rem;
+}
+
+.pause-overlay__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.25rem;
+}
+
+.pause-overlay__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pause-overlay__section h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 213, 255, 0.9);
+}
+
+.pause-overlay__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pause-overlay__empty {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(10, 15, 35, 0.7);
+  border: 1px dashed rgba(118, 169, 255, 0.35);
+  color: rgba(200, 218, 255, 0.7);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.pause-overlay__card {
+  border-radius: 16px;
+  border: 1px solid rgba(121, 205, 255, 0.45);
+  background: linear-gradient(180deg, rgba(16, 20, 45, 0.95) 0%, rgba(8, 10, 28, 0.98) 100%);
+  box-shadow: 0 20px 48px rgba(16, 20, 48, 0.55);
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: #ffffff;
+}
+
+.pause-overlay__card--enemy {
+  border-color: rgba(255, 190, 140, 0.5);
+  background: linear-gradient(180deg, rgba(55, 24, 36, 0.92) 0%, rgba(30, 14, 26, 0.95) 100%);
+  box-shadow: 0 20px 48px rgba(70, 24, 48, 0.4);
+}
+
+.pause-overlay__card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.pause-overlay__card h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+
+.pause-overlay__card p {
+  margin: 0;
+  color: rgba(226, 235, 255, 0.82);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.pause-overlay__count {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(118, 169, 255, 0.18);
+  border: 1px solid rgba(118, 169, 255, 0.45);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+}
+
+.pause-overlay__tag {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(174, 214, 255, 0.9);
+}
+
+.pause-overlay__card--player[data-rarity='common'] {
+  border-color: rgba(121, 205, 255, 0.6);
+}
+
+.pause-overlay__card--player[data-rarity='uncommon'] {
+  border-color: rgba(138, 255, 210, 0.65);
+}
+
+.pause-overlay__card--player[data-rarity='uncommon'] .pause-overlay__tag {
+  color: rgba(138, 255, 210, 0.95);
+}
+
+.pause-overlay__card--player[data-rarity='rare'] {
+  border-color: rgba(255, 168, 255, 0.75);
+  box-shadow: 0 22px 54px rgba(110, 48, 140, 0.45);
+}
+
+.pause-overlay__card--player[data-rarity='rare'] .pause-overlay__tag {
+  color: rgba(255, 200, 255, 0.95);
+}
+
+.pause-overlay__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pause-overlay__resume {
+  pointer-events: auto;
+  cursor: pointer;
+  padding: 0.6rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 169, 255, 0.6);
+  background: linear-gradient(90deg, rgba(35, 80, 140, 0.9) 0%, rgba(54, 120, 210, 0.85) 100%);
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  box-shadow: 0 12px 34px rgba(56, 120, 200, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.pause-overlay__resume:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 38px rgba(86, 180, 255, 0.45);
+  filter: brightness(1.05);
+}
+
+.pause-overlay__resume:active {
+  transform: translateY(0);
+  box-shadow: 0 10px 24px rgba(86, 180, 255, 0.35);
+}
+
+.pause-overlay__resume:focus-visible {
+  outline: 2px solid rgba(173, 226, 255, 0.9);
+  outline-offset: 2px;
+}
+
+.pause-overlay__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(199, 216, 255, 0.72);
+  text-align: center;
+}
+
+  @media (max-width: 640px) {
+    #app {
+      padding: 0;
+    }
+    .game-shell {
+      border-radius: 0;
+      border-width: 0;
+    }
+    .pause-overlay {
+      padding: 1.25rem;
+    }
+    .pause-overlay__panel {
+      max-height: calc(100% - 1rem);
+      padding: 1.5rem 1.25rem;
+    }
+  }

--- a/src/ui/PauseOverlay.ts
+++ b/src/ui/PauseOverlay.ts
@@ -1,0 +1,216 @@
+import type { EnemyModifierSummary, ModifierRarity, RunModifierId } from '../game/types';
+import { ALL_DRAFT_MODIFIERS } from '../game/modifiers';
+
+const modifierLookup = new Map(
+  ALL_DRAFT_MODIFIERS.map((modifier) => [modifier.id, modifier]),
+);
+
+export interface PauseOverlayPlayerModifier {
+  id: RunModifierId;
+  count: number;
+}
+
+export class PauseOverlay {
+  public readonly element: HTMLDivElement;
+
+  private readonly playerList: HTMLDivElement;
+  private readonly playerEmpty: HTMLParagraphElement;
+  private readonly enemyList: HTMLDivElement;
+  private readonly enemyEmpty: HTMLParagraphElement;
+  private readonly resumeButton: HTMLButtonElement;
+  private resumeHandler?: () => void;
+
+  constructor() {
+    this.element = document.createElement('div');
+    this.element.className = 'pause-overlay';
+    this.element.setAttribute('aria-hidden', 'true');
+    this.element.addEventListener('click', (event) => {
+      if (event.target === this.element) {
+        this.resumeHandler?.();
+      }
+    });
+
+    const panel = document.createElement('div');
+    panel.className = 'pause-overlay__panel';
+
+    const heading = document.createElement('div');
+    heading.className = 'pause-overlay__heading';
+
+    const title = document.createElement('h2');
+    title.textContent = 'Run Paused';
+
+    const subtitle = document.createElement('p');
+    subtitle.textContent = 'Review your loadout and current threats before resuming.';
+
+    heading.append(title, subtitle);
+
+    const content = document.createElement('div');
+    content.className = 'pause-overlay__content';
+
+    const playerSection = this.createSection(
+      'Loadout Modifiers',
+      'Collect upgrades during your run to expand your arsenal.',
+    );
+    this.playerList = playerSection.list;
+    this.playerEmpty = playerSection.empty;
+
+    const enemySection = this.createSection(
+      'Enemy Mutations',
+      'No enemy modifiers are active this wave.',
+    );
+    this.enemyList = enemySection.list;
+    this.enemyEmpty = enemySection.empty;
+
+    content.append(playerSection.section, enemySection.section);
+
+    const actions = document.createElement('div');
+    actions.className = 'pause-overlay__actions';
+
+    this.resumeButton = document.createElement('button');
+    this.resumeButton.type = 'button';
+    this.resumeButton.className = 'pause-overlay__resume';
+    this.resumeButton.textContent = 'Resume Run';
+    this.resumeButton.addEventListener('click', () => {
+      this.resumeHandler?.();
+    });
+
+    const hint = document.createElement('p');
+    hint.className = 'pause-overlay__hint';
+    hint.textContent = 'Tap outside or press Resume to continue.';
+
+    actions.append(this.resumeButton, hint);
+
+    panel.append(heading, content, actions);
+    this.element.append(panel);
+
+    this.setPlayerModifiers([]);
+    this.setEnemyModifiers([]);
+  }
+
+  setVisible(visible: boolean) {
+    this.element.classList.toggle('visible', visible);
+    this.element.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    if (visible) {
+      this.resumeButton.focus();
+    }
+  }
+
+  onResumeRequested(handler: () => void) {
+    this.resumeHandler = handler;
+  }
+
+  setPlayerModifiers(modifiers: PauseOverlayPlayerModifier[]) {
+    const fragment = document.createDocumentFragment();
+
+    const entries = modifiers
+      .map((modifier) => {
+        const definition = modifierLookup.get(modifier.id);
+        if (!definition) return null;
+        return { definition, count: modifier.count };
+      })
+      .filter((entry): entry is { definition: (typeof ALL_DRAFT_MODIFIERS)[number]; count: number } =>
+        entry !== null,
+      )
+      .sort((a, b) => a.definition.name.localeCompare(b.definition.name));
+
+    for (const entry of entries) {
+      fragment.appendChild(
+        this.createPlayerCard(
+          entry.definition.name,
+          entry.definition.description,
+          entry.definition.rarity,
+          entry.count,
+        ),
+      );
+    }
+
+    this.playerList.replaceChildren(fragment);
+    const hasEntries = entries.length > 0;
+    this.playerList.hidden = !hasEntries;
+    this.playerEmpty.hidden = hasEntries;
+  }
+
+  setEnemyModifiers(modifiers: EnemyModifierSummary[]) {
+    const fragment = document.createDocumentFragment();
+
+    for (const modifier of modifiers) {
+      fragment.appendChild(this.createEnemyCard(modifier.name, modifier.description));
+    }
+
+    this.enemyList.replaceChildren(fragment);
+    const hasEntries = modifiers.length > 0;
+    this.enemyList.hidden = !hasEntries;
+    this.enemyEmpty.hidden = hasEntries;
+  }
+
+  private createSection(title: string, emptyMessage: string) {
+    const section = document.createElement('section');
+    section.className = 'pause-overlay__section';
+
+    const heading = document.createElement('h3');
+    heading.textContent = title;
+
+    const list = document.createElement('div');
+    list.className = 'pause-overlay__list';
+
+    const empty = document.createElement('p');
+    empty.className = 'pause-overlay__empty';
+    empty.textContent = emptyMessage;
+
+    section.append(heading, list, empty);
+
+    return { section, list, empty };
+  }
+
+  private createPlayerCard(
+    name: string,
+    description: string,
+    rarity: ModifierRarity,
+    count: number,
+  ): HTMLDivElement {
+    const card = document.createElement('div');
+    card.className = 'pause-overlay__card pause-overlay__card--player';
+    card.dataset.rarity = rarity;
+
+    const header = document.createElement('div');
+    header.className = 'pause-overlay__card-header';
+
+    const title = document.createElement('h4');
+    title.textContent = name;
+
+    header.appendChild(title);
+
+    if (count > 1) {
+      const countBadge = document.createElement('span');
+      countBadge.className = 'pause-overlay__count';
+      countBadge.textContent = `×${count}`;
+      header.appendChild(countBadge);
+    }
+
+    const rarityLabel = document.createElement('span');
+    rarityLabel.className = `pause-overlay__tag rarity-${rarity}`;
+    rarityLabel.textContent = rarity.toUpperCase();
+
+    const body = document.createElement('p');
+    body.textContent = description;
+
+    card.append(header, rarityLabel, body);
+
+    return card;
+  }
+
+  private createEnemyCard(name: string, description: string): HTMLDivElement {
+    const card = document.createElement('div');
+    card.className = 'pause-overlay__card pause-overlay__card--enemy';
+
+    const title = document.createElement('h4');
+    title.textContent = name;
+
+    const body = document.createElement('p');
+    body.textContent = description;
+
+    card.append(title, body);
+
+    return card;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a pause overlay that lists collected player modifiers and current enemy mutations while the game is paused
- track modifier selections in the game state, feed the overlay, and handle resume interactions from the overlay
- wire the overlay into the app bootstrap and style the new UI with responsive layout and resume control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9250282b8832da396d87fb48c0f41