### PR TITLE
Add intro menu with difficulty selection and pause menu quit

### DIFF
--- a/src/game/difficulty.ts
+++ b/src/game/difficulty.ts
@@ -1,0 +1,39 @@
+import type { DifficultyDefinition } from './types';
+
+export const DIFFICULTIES: DifficultyDefinition[] = [
+  {
+    id: 'rookie',
+    name: 'Rookie Protocol',
+    tagline: 'For new operatives.',
+    description:
+      'Amplified cannon output and softened hostiles give you breathing room to learn the sling.',
+    playerDamageMultiplier: 1.25,
+    enemyHpMultiplier: 0.75,
+  },
+  {
+    id: 'vanguard',
+    name: 'Vanguard Run',
+    tagline: 'Standard threat profile.',
+    description:
+      'Baseline Slingpunk tuning where enemy resilience and cannon output are evenly matched.',
+    playerDamageMultiplier: 1,
+    enemyHpMultiplier: 1,
+    isDefault: true,
+  },
+  {
+    id: 'overclocked',
+    name: 'Overclocked Siege',
+    tagline: 'For hardened agents.',
+    description:
+      'Outnumbered and outgunned—hostiles surge with reinforced plating while your cannon is throttled.',
+    playerDamageMultiplier: 0.85,
+    enemyHpMultiplier: 1.35,
+  },
+];
+
+export const DEFAULT_DIFFICULTY =
+  DIFFICULTIES.find((difficulty) => difficulty.isDefault) ?? DIFFICULTIES[0];
+
+export function getDifficultyById(id: string): DifficultyDefinition | undefined {
+  return DIFFICULTIES.find((difficulty) => difficulty.id === id);
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -5,6 +5,16 @@ export interface Vector2 {
 
 export type ModifierRarity = 'common' | 'uncommon' | 'rare';
 
+export interface DifficultyDefinition {
+  id: string;
+  name: string;
+  tagline: string;
+  description: string;
+  playerDamageMultiplier: number;
+  enemyHpMultiplier: number;
+  isDefault?: boolean;
+}
+
 export type RunModifierId =
   | 'bulwarkCore'
   | 'cryoCoating'

--- a/src/style.css
+++ b/src/style.css
@@ -183,6 +183,7 @@ canvas.game-canvas {
   text-align: center;
   color: #f2f8ff;
   font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+  z-index: 20;
 }
 
 .power-draft.visible {
@@ -290,6 +291,7 @@ canvas.game-canvas {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.25s ease;
+  z-index: 30;
 }
 
 .pause-overlay.visible {
@@ -451,8 +453,10 @@ canvas.game-canvas {
 .pause-overlay__actions {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 0.75rem;
+  width: min(100%, 320px);
+  margin-inline: auto;
 }
 
 .pause-overlay__resume {
@@ -469,6 +473,38 @@ canvas.game-canvas {
   font-size: 0.9rem;
   box-shadow: 0 12px 34px rgba(56, 120, 200, 0.45);
   transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.pause-overlay__quit {
+  pointer-events: auto;
+  cursor: pointer;
+  padding: 0.55rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 116, 116, 0.55);
+  background: linear-gradient(90deg, rgba(120, 38, 58, 0.85) 0%, rgba(165, 54, 78, 0.82) 100%);
+  color: #ffeaea;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  box-shadow: 0 12px 30px rgba(165, 54, 78, 0.4);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.pause-overlay__quit:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(205, 74, 98, 0.45);
+  filter: brightness(1.05);
+}
+
+.pause-overlay__quit:active {
+  transform: translateY(0);
+  box-shadow: 0 10px 26px rgba(165, 54, 78, 0.35);
+}
+
+.pause-overlay__quit:focus-visible {
+  outline: 2px solid rgba(255, 176, 176, 0.85);
+  outline-offset: 2px;
 }
 
 .pause-overlay__resume:hover {
@@ -492,6 +528,158 @@ canvas.game-canvas {
   font-size: 0.85rem;
   color: rgba(199, 216, 255, 0.72);
   text-align: center;
+}
+
+.intro-menu {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 2rem;
+  background: rgba(6, 4, 18, 0.92);
+  backdrop-filter: blur(12px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  color: #f2f8ff;
+  font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+  z-index: 40;
+}
+
+.intro-menu.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.intro-menu__panel {
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 2.25rem 2rem;
+  border-radius: 26px;
+  border: 1px solid rgba(118, 169, 255, 0.45);
+  background: linear-gradient(180deg, rgba(16, 20, 44, 0.95) 0%, rgba(8, 12, 28, 0.98) 100%);
+  box-shadow: 0 30px 80px rgba(8, 12, 32, 0.68);
+}
+
+.intro-menu__heading h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3.4vw, 2.6rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #9de2ff;
+}
+
+.intro-menu__heading p {
+  margin: 0.5rem 0 0;
+  color: rgba(214, 230, 255, 0.78);
+  font-size: 1rem;
+}
+
+.intro-menu__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.intro-menu__card {
+  border-radius: 22px;
+  border: 1px solid rgba(118, 169, 255, 0.35);
+  background: linear-gradient(180deg, rgba(20, 24, 50, 0.96) 0%, rgba(8, 12, 28, 0.98) 100%);
+  box-shadow: 0 20px 52px rgba(12, 16, 32, 0.55);
+  padding: 1.35rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.intro-menu__card:hover,
+.intro-menu__card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 64px rgba(94, 160, 255, 0.5);
+  border-color: rgba(150, 205, 255, 0.65);
+  outline: none;
+}
+
+.intro-menu__card.selected {
+  border-color: rgba(138, 255, 210, 0.75);
+  box-shadow: 0 28px 70px rgba(74, 198, 164, 0.5);
+}
+
+.intro-menu__card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.intro-menu__card-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.06em;
+}
+
+.intro-menu__tagline {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(163, 219, 255, 0.82);
+}
+
+.intro-menu__card p {
+  margin: 0;
+  color: rgba(218, 230, 255, 0.78);
+  line-height: 1.45;
+}
+
+.intro-menu__modifiers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.92rem;
+  color: rgba(175, 220, 255, 0.85);
+}
+
+.intro-menu__start {
+  pointer-events: auto;
+  cursor: pointer;
+  align-self: flex-end;
+  padding: 0.65rem 1.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 169, 255, 0.6);
+  background: linear-gradient(90deg, rgba(30, 86, 210, 0.95) 0%, rgba(74, 140, 255, 0.92) 100%);
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  box-shadow: 0 16px 42px rgba(74, 140, 255, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.intro-menu__start:hover:enabled {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 48px rgba(124, 178, 255, 0.5);
+  filter: brightness(1.05);
+}
+
+.intro-menu__start:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.intro-menu__start:focus-visible {
+  outline: 2px solid rgba(173, 226, 255, 0.9);
+  outline-offset: 2px;
 }
 
   @media (max-width: 640px) {

--- a/src/ui/IntroMenu.ts
+++ b/src/ui/IntroMenu.ts
@@ -1,0 +1,163 @@
+import type { DifficultyDefinition } from '../game/types';
+
+export class IntroMenu {
+  public readonly element: HTMLDivElement;
+
+  private readonly startButton: HTMLButtonElement;
+  private readonly cardLookup = new Map<string, HTMLButtonElement>();
+  private readonly difficulties: DifficultyDefinition[];
+
+  private startHandler?: (difficulty: DifficultyDefinition) => void;
+  private selectedId?: string;
+
+  constructor(difficulties: DifficultyDefinition[]) {
+    this.difficulties = difficulties;
+    this.element = document.createElement('div');
+    this.element.className = 'intro-menu visible';
+    this.element.setAttribute('aria-hidden', 'false');
+
+    const panel = document.createElement('div');
+    panel.className = 'intro-menu__panel';
+
+    const heading = document.createElement('div');
+    heading.className = 'intro-menu__heading';
+
+    const title = document.createElement('h1');
+    title.textContent = 'Slingpunk Deployment';
+    const subtitle = document.createElement('p');
+    subtitle.textContent = 'Configure your run parameters before launching the next operation.';
+    heading.append(title, subtitle);
+
+    const grid = document.createElement('div');
+    grid.className = 'intro-menu__grid';
+
+    for (const difficulty of difficulties) {
+      const card = this.createDifficultyCard(difficulty);
+      grid.appendChild(card);
+      this.cardLookup.set(difficulty.id, card);
+    }
+
+    this.startButton = document.createElement('button');
+    this.startButton.type = 'button';
+    this.startButton.className = 'intro-menu__start';
+    this.startButton.textContent = 'Launch Run';
+    this.startButton.disabled = true;
+    this.startButton.addEventListener('click', () => {
+      if (!this.selectedId) return;
+      const difficulty = this.difficulties.find((entry) => entry.id === this.selectedId);
+      if (!difficulty) return;
+      this.startHandler?.(difficulty);
+    });
+
+    panel.append(heading, grid, this.startButton);
+    this.element.append(panel);
+
+    const defaultDifficulty =
+      difficulties.find((entry) => entry.isDefault) ?? difficulties[0];
+    if (defaultDifficulty) {
+      this.setSelected(defaultDifficulty.id);
+    }
+  }
+
+  onStart(handler: (difficulty: DifficultyDefinition) => void) {
+    this.startHandler = handler;
+  }
+
+  show() {
+    this.element.classList.add('visible');
+    this.element.setAttribute('aria-hidden', 'false');
+    if (this.selectedId) {
+      this.cardLookup.get(this.selectedId)?.focus();
+    } else {
+      this.startButton.focus();
+    }
+  }
+
+  hide() {
+    this.element.classList.remove('visible');
+    this.element.setAttribute('aria-hidden', 'true');
+  }
+
+  selectDifficulty(id: string) {
+    this.setSelected(id);
+  }
+
+  private setSelected(id: string) {
+    if (this.selectedId === id) return;
+    if (this.selectedId) {
+      const previous = this.cardLookup.get(this.selectedId);
+      previous?.classList.remove('selected');
+      previous?.setAttribute('aria-pressed', 'false');
+    }
+
+    const next = this.cardLookup.get(id);
+    if (!next) {
+      this.selectedId = undefined;
+      this.startButton.disabled = true;
+      this.startButton.textContent = 'Launch Run';
+      return;
+    }
+
+    this.selectedId = id;
+    next.classList.add('selected');
+    next.setAttribute('aria-pressed', 'true');
+    this.startButton.disabled = false;
+    this.startButton.textContent = `Launch ${next.dataset.name ?? 'Run'}`;
+  }
+
+  private createDifficultyCard(difficulty: DifficultyDefinition) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'intro-menu__card';
+    button.dataset.difficulty = difficulty.id;
+    button.dataset.name = difficulty.name;
+    button.setAttribute('aria-pressed', 'false');
+
+    const header = document.createElement('div');
+    header.className = 'intro-menu__card-header';
+
+    const title = document.createElement('h2');
+    title.textContent = difficulty.name;
+
+    const tagline = document.createElement('span');
+    tagline.className = 'intro-menu__tagline';
+    tagline.textContent = difficulty.tagline;
+
+    header.append(title, tagline);
+
+    const description = document.createElement('p');
+    description.textContent = difficulty.description;
+
+    const modifiers = document.createElement('ul');
+    modifiers.className = 'intro-menu__modifiers';
+
+    const damageItem = document.createElement('li');
+    damageItem.textContent = this.describeMultiplier(
+      difficulty.playerDamageMultiplier,
+      'Player damage',
+    );
+    const hpItem = document.createElement('li');
+    hpItem.textContent = this.describeMultiplier(difficulty.enemyHpMultiplier, 'Enemy HP');
+
+    modifiers.append(damageItem, hpItem);
+
+    button.append(header, description, modifiers);
+
+    button.addEventListener('click', () => {
+      this.setSelected(difficulty.id);
+    });
+
+    button.addEventListener('dblclick', () => {
+      this.setSelected(difficulty.id);
+      this.startHandler?.(difficulty);
+    });
+
+    return button;
+  }
+
+  private describeMultiplier(multiplier: number, label: string) {
+    const percentage = Math.round((multiplier - 1) * 100);
+    const sign = percentage > 0 ? '+' : '';
+    return `${label}: ${sign}${percentage}%`;
+  }
+}

--- a/src/ui/PauseOverlay.ts
+++ b/src/ui/PauseOverlay.ts
@@ -18,7 +18,9 @@ export class PauseOverlay {
   private readonly enemyList: HTMLDivElement;
   private readonly enemyEmpty: HTMLParagraphElement;
   private readonly resumeButton: HTMLButtonElement;
+  private readonly quitButton: HTMLButtonElement;
   private resumeHandler?: () => void;
+  private quitHandler?: () => void;
 
   constructor() {
     this.element = document.createElement('div');
@@ -74,11 +76,19 @@ export class PauseOverlay {
       this.resumeHandler?.();
     });
 
+    this.quitButton = document.createElement('button');
+    this.quitButton.type = 'button';
+    this.quitButton.className = 'pause-overlay__quit';
+    this.quitButton.textContent = 'Quit to Menu';
+    this.quitButton.addEventListener('click', () => {
+      this.quitHandler?.();
+    });
+
     const hint = document.createElement('p');
     hint.className = 'pause-overlay__hint';
-    hint.textContent = 'Tap outside or press Resume to continue.';
+    hint.textContent = 'Tap outside or choose an action below.';
 
-    actions.append(this.resumeButton, hint);
+    actions.append(this.resumeButton, this.quitButton, hint);
 
     panel.append(heading, content, actions);
     this.element.append(panel);
@@ -97,6 +107,10 @@ export class PauseOverlay {
 
   onResumeRequested(handler: () => void) {
     this.resumeHandler = handler;
+  }
+
+  onQuitRequested(handler: () => void) {
+    this.quitHandler = handler;
   }
 
   setPlayerModifiers(modifiers: PauseOverlayPlayerModifier[]) {


### PR DESCRIPTION
## Summary
- add reusable difficulty definitions and an intro menu overlay so players select a run modifier before starting
- update the core Game logic to respect player damage / enemy HP difficulty multipliers, allow clean disposal, and gate input when not running
- extend the pause overlay with a quit-to-menu action and add styling for the new overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4cd4eadc832db1fdb2a6f88c6736