### PR TITLE
Add Nova Pulse special meter and ability

### DIFF
--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -68,6 +68,10 @@ export interface HudData {
   lives: number;
   wave: number;
   lastModifier?: RunModifierId;
+  specialCharge: number;
+  specialMax: number;
+  specialReady: boolean;
+  specialName: string;
 }
 
 export type EnemyKind =

--- a/src/style.css
+++ b/src/style.css
@@ -114,6 +114,131 @@ canvas.game-canvas {
   background: linear-gradient(90deg, #ff3cf9 0%, #ffc43c 100%);
 }
 
+.focus-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.focus-widget {
+  pointer-events: auto;
+  position: relative;
+  width: clamp(150px, 35vw, 200px);
+  aspect-ratio: 1;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.18s ease, filter 0.18s ease;
+}
+
+.focus-widget:hover {
+  transform: translateY(-1px);
+}
+
+.focus-widget.is-ready {
+  filter: drop-shadow(0 0 14px rgba(118, 255, 227, 0.55));
+  transform: translateY(-2px);
+}
+
+.focus-widget.is-ready:hover {
+  transform: translateY(-4px);
+}
+
+.focus-widget:focus-visible {
+  outline: 2px solid rgba(118, 255, 227, 0.9);
+  outline-offset: 4px;
+}
+
+.focus-widget__ring {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.focus-widget__ring-bg {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 12;
+}
+
+.focus-widget__ring-fill {
+  fill: none;
+  stroke-width: 12;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+}
+
+.focus-widget__core {
+  position: absolute;
+  inset: 18%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: unset;
+  width: auto;
+  height: auto;
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+}
+
+.focus-widget__core.metric {
+  min-width: unset;
+}
+
+.focus-widget__core.pill {
+  border-radius: 28px;
+  border: 1px solid rgba(118, 255, 227, 0.38);
+  box-shadow: inset 0 0 18px rgba(118, 255, 227, 0.2);
+  background: rgba(10, 20, 35, 0.68);
+}
+
+.focus-widget__core .metric-label {
+  font-size: 0.7em;
+  letter-spacing: 0.12em;
+}
+
+.focus-widget__core .metric-value {
+  font-size: 1.3em;
+}
+
+.focus-widget__core .focus-bar {
+  width: 100%;
+  height: 7px;
+}
+
+.focus-widget__status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.5rem;
+  font-size: 0.7em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(164, 255, 240, 0.88);
+}
+
+.focus-widget__name {
+  font-weight: 600;
+}
+
+.focus-widget__value {
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.focus-wrapper__loadout {
+  align-self: stretch;
+  width: clamp(180px, 38vw, 220px);
+  text-align: center;
+}
+
 .control-hint {
   display: inline-flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add the Nova Pulse special meter UI around the focus widget with readiness feedback
- implement Nova Pulse charge gain, shard siphon effects, and activation logic that repels/slows enemies
- update styling to showcase the circular special meter and align the bottom HUD stack

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cb9d7291dc832db8fa5b8ad6ba5a55