### PR TITLE
Add wave transition cinematics

### DIFF
--- a/src/game/waves/WaveManager.ts
+++ b/src/game/waves/WaveManager.ts
@@ -75,6 +75,14 @@ export class WaveManager {
     const tuning = buildEnemyTuning(waveNumber);
     this.scaling = tuning.scaling;
 
+    this.game.onWaveStart({
+      blueprintId: blueprint.waveId,
+      waveNumber,
+      modifiers: tuning.modifiers,
+      scaling: tuning.scaling,
+    });
+
+    const introDelay = this.game.consumeWaveIntroDelay();
     this.spawns = blueprint.enemies.map((config) => {
       const scaledConfig: WaveEnemyConfig = {
         type: config.type,
@@ -86,15 +94,9 @@ export class WaveManager {
       return {
         config: scaledConfig,
         spawned: 0,
-        nextTime: this.elapsed + Math.random() * Math.min(2, scaledConfig.cadence),
+        nextTime:
+          this.elapsed + introDelay + Math.random() * Math.min(2, scaledConfig.cadence),
       };
-    });
-
-    this.game.onWaveStart({
-      blueprintId: blueprint.waveId,
-      waveNumber,
-      modifiers: tuning.modifiers,
-      scaling: tuning.scaling,
     });
   }
 


### PR DESCRIPTION
## Summary
- add a reusable wave transition effect that drives pre-wave and post-wave energy overlays, text, and impact pulses
- delay enemy spawns for the intro animation and sprinkle in transition impact waves to punctuate the round changeovers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7ccd1464832dafcef12002c207ac