### PR TITLE
Fix pause overlay resume and prevent focus bleed

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -253,13 +253,21 @@ export class Game {
   togglePause() {
     if (!this.running) return;
     if (this.pauseLocked) return;
-    if (this.pauseInputCooldown > 0) return;
-    this.paused = !this.paused;
-    this.hud.setPaused(this.paused);
-    this.syncPlayerModifiersOverlay();
-    this.pauseOverlay.setVisible(this.paused);
-    this.pauseInputCooldown = 0.2;
-    if (!this.paused) {
+    const wasPaused = this.paused;
+    if (!wasPaused && this.pauseInputCooldown > 0) return;
+
+    const nextPaused = !wasPaused;
+    this.paused = nextPaused;
+    this.hud.setPaused(nextPaused);
+    if (nextPaused) {
+      this.syncPlayerModifiersOverlay();
+    }
+    this.pauseOverlay.setVisible(nextPaused);
+
+    if (nextPaused) {
+      this.pauseInputCooldown = 0.2;
+    } else {
+      this.pauseInputCooldown = 0;
       this.lastTime = performance.now();
     }
   }

--- a/src/ui/PauseOverlay.ts
+++ b/src/ui/PauseOverlay.ts
@@ -101,7 +101,13 @@ export class PauseOverlay {
     this.element.classList.toggle('visible', visible);
     this.element.setAttribute('aria-hidden', visible ? 'false' : 'true');
     if (visible) {
-      this.resumeButton.focus();
+      this.resumeButton.focus({ preventScroll: true });
+    } else {
+      if (this.element.contains(document.activeElement)) {
+        (document.activeElement as HTMLElement).blur();
+      }
+      this.resumeButton.blur();
+      this.quitButton.blur();
     }
   }
 


### PR DESCRIPTION
## Summary
- allow the pause toggle to resume even when the cooldown is active and reset the cooldown on unpause
- keep the pause overlay modifier list in sync only when it is shown and focus the resume button without scrolling
- blur pause overlay controls when it is hidden to avoid accidental quit requests while drafting upgrades

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8571c2fc832db71c50444cdf59ed