### PR TITLE
Hide pause overlay during modifier draft

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -396,6 +396,7 @@ export class Game {
     this.pauseLocked = true;
     this.paused = true;
     this.hud.setPaused(true);
+    this.pauseOverlay.setVisible(false);
 
     let cancelled = false;
     try {


### PR DESCRIPTION
## Summary
- ensure the pause overlay is explicitly hidden when entering the modifier draft
- prevent the pause layer from capturing clicks meant for the draft overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca01cbba0832dacbf9578f492c05c